### PR TITLE
import Vec and format

### DIFF
--- a/src/rw.rs
+++ b/src/rw.rs
@@ -1,4 +1,5 @@
 use super::*;
+use ark_std::format;
 
 
 /// Scale `Input` error wrapped for passage through Arkworks' `CanonicalDeserialize`

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 
 
-use ark_std::{cmp::PartialEq, fmt::Debug, UniformRand};  // io::{self, Read, Write}
+use ark_std::{cmp::PartialEq, fmt::Debug, UniformRand, vec::Vec};  // io::{self, Read, Write}
 
 use ark_serialize::{CanonicalSerialize,CanonicalDeserialize};
 


### PR DESCRIPTION
When using ark-scale it complains about missing imports of `ark_st::vec::Vec` and `ark_std::format`. This PR's adds those imports.