### PR TITLE
Implement TypeInfo for ArkScale and more flexible ArkScaleMaxEncodedLen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ark-scale"
 description = "Arkworks serialization wrapped in Parity SCALE codec"
 authors = ["Jeff Burdges <jeff@web3.foundation>"]
-version = "0.0.10"
+version = "0.0.11"
 repository = "https://github.com/w3f/ark-scale"
 edition = "2021"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ license = "MIT/Apache-2.0"
 
 
 [dependencies]
-parity-scale-codec = { version = "3.6", default-features = false, features = ["max-encoded-len"] }
+scale-codec = { package = "parity-scale-codec", version = "3.6", default-features = false, features = ["max-encoded-len"] }
+scale-info = { version = "2.5", default-features = false }
 ark-std = { version = "0.4", default-features = false }
 ark-serialize = { version = "0.4.2", default-features = false, features = [ "derive" ] }
 
@@ -30,7 +31,8 @@ rand_core = { version = "0.6", features = [ "getrandom" ] }
 [features]
 default = ["std"] # "hazmat"
 std = [
-    "parity-scale-codec/std",
+    "scale-codec/std",
+    "scale-info/std",
     "ark-std/std",
     "ark-serialize/std",
     "ark-bls12-381/std",

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1,20 +1,20 @@
 
-use ark_serialize::{Compress};
+use ark_serialize::Compress;
 
-use crate::{self as ark_scale, ArkScaleMaxEncodedLen}; // ArkScale,ArkScaleRef,ConstEncodedLen
+use crate::ArkScaleMaxEncodedLen; // ArkScale,ArkScaleRef,ConstEncodedLen
 
 use ark_ec::models::{short_weierstrass as sw, twisted_edwards as te};
 
 impl<P: sw::SWCurveConfig> ArkScaleMaxEncodedLen for sw::Affine<P> {
     #[inline]
-    fn max_encoded_len() -> usize {
-        P::serialized_size(Compress::Yes)
+    fn max_encoded_len(compress: Compress) -> usize {
+        P::serialized_size(compress)
     }
 }
 
 impl<P: te::TECurveConfig> ArkScaleMaxEncodedLen for te::Affine<P> {
     #[inline]
-    fn max_encoded_len() -> usize {
-        P::serialized_size(Compress::Yes)
+    fn max_encoded_len(compress: Compress) -> usize {
+        P::serialized_size(compress)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,9 +92,9 @@ pub const fn is_validated(u: Usage) -> Validate {
 pub const WIRE: Usage = make_usage(Compress::Yes, Validate::Yes);
 
 /// ArkScale usage which neither compresses nor validates inputs,
-/// only for usage in host calls where the runtime already performed
+/// only for usage in host calls and on-chain storage where the runtime already performed
 /// validation checks.
-pub const HOST_CALL: Usage = make_usage(Compress::No, Validate::No);
+pub const HOST: Usage = make_usage(Compress::No, Validate::No);
 
 /// Arkworks type wrapped for serialization by Scale
 #[derive(Clone, Eq, PartialEq, Debug)] // CanonicalSerialize, CanonicalDeserialize

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,14 +153,14 @@ impl<T: CanonicalSerialize, const U: Usage> Encode for ArkScale<T, U> {
     }
 }
 
-impl<T: 'static + CanonicalSerialize + ArkScaleMaxEncodedLen, const U: Usage> TypeInfo for ArkScale<T, U> {
+impl<T: 'static + ArkScaleMaxEncodedLen, const U: Usage> TypeInfo for ArkScale<T, U> {
     type Identity = Self;
 
     fn type_info() -> scale_info::Type {
         let path = scale_info::Path::new(core::any::type_name::<Self>(), module_path!());
         let array_type_def = scale_info::TypeDefArray {
-            len: <Self as MaxEncodedLen>::max_encoded_len() as u32,
-            type_param: scale_info::MetaType::new::<Self>(),
+            len: T::max_encoded_len(is_compressed(U)) as u32,
+            type_param: scale_info::MetaType::new::<u8>(),
         };
         let type_def = scale_info::TypeDef::Array(array_type_def);
         scale_info::Type { path, type_params: Vec::new(), type_def, docs: Vec::new() }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,9 @@ use ark_serialize::{
 };
 pub use ark_serialize::{self as ark_serialize};
 
-pub use parity_scale_codec::{self as scale, MaxEncodedLen}; // max_encoded_len::ConstEncodedLen
+pub use scale_codec::{self as scale, MaxEncodedLen}; // max_encoded_len::ConstEncodedLen
 use scale::{Decode, Encode, EncodeLike, Input, Output};
+use scale_info::TypeInfo;
 // type ScaleResult<T> = Result<T,scale::Error>;
 
 pub mod rw;
@@ -149,6 +150,20 @@ impl<T: CanonicalSerialize, const U: Usage> Encode for ArkScale<T, U> {
 
     fn encoded_size(&self) -> usize {
         self.0.serialized_size(is_compressed(U))
+    }
+}
+
+impl<T: 'static + CanonicalSerialize + ArkScaleMaxEncodedLen, const U: Usage> TypeInfo for ArkScale<T, U> {
+    type Identity = Self;
+
+    fn type_info() -> scale_info::Type {
+        let path = scale_info::Path::new(core::any::type_name::<Self>(), module_path!());
+        let array_type_def = scale_info::TypeDefArray {
+            len: <Self as MaxEncodedLen>::max_encoded_len() as u32,
+            type_param: scale_info::MetaType::new::<Self>(),
+        };
+        let type_def = scale_info::TypeDef::Array(array_type_def);
+        scale_info::Type { path, type_params: Vec::new(), type_def, docs: Vec::new() }
     }
 }
 
@@ -327,17 +342,15 @@ macro_rules! impl_encode_via_ark {
 #[macro_export]
 macro_rules! impl_scale_via_ark {
     ($t:ty) => {
+        impl Decode for $t {
+            ark_scale::impl_decode_via_ark!();
+        }
 
-impl Decode for $t {
-    ark_scale::impl_decode_via_ark!();
-}
+        impl Encode for $t {
+            ark_scale::impl_encode_via_ark!();
+        }
 
-impl Encode for $t {
-    ark_scale::impl_encode_via_ark!();
-}
-
-impl ark_scale::scale::EncodeLike for $t {}
-
+        impl ark_scale::scale::EncodeLike for $t {}
     }
 } // macro_rules! impl_scale_via_ark
 
@@ -351,9 +364,9 @@ macro_rules! impl_body_max_encode_len {
     };
     ($t:ty) => {
         #[inline]
-        fn max_encoded_len() -> usize {
+        fn max_encoded_len(compress: ark_serialize::Compress) -> usize {
             use ark_serialize::{CanonicalSerialize}; 
-            <$t as ark_std::Zero>::zero().compressed_size()
+            <$t as ark_std::Zero>::zero().serialized_size(compress)
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub const WIRE: Usage = make_usage(Compress::Yes, Validate::Yes);
 /// ArkScale usage which neither compresses nor validates inputs,
 /// only for usage in host calls and on-chain storage where the runtime already performed
 /// validation checks.
-pub const HOST: Usage = make_usage(Compress::No, Validate::No);
+pub const HOST_CALL: Usage = make_usage(Compress::No, Validate::No);
 
 /// Arkworks type wrapped for serialization by Scale
 #[derive(Clone, Eq, PartialEq, Debug)] // CanonicalSerialize, CanonicalDeserialize

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -90,7 +90,7 @@ where
     run_test::<T, WIRE>();
     run_test::<T, { make_usage(Compress::Yes, Validate::No) }>();
     // run_test::<T,{ make_usage(Compress::No, Validate::Yes) }>();
-    run_test::<T, HOST_CALL>();
+    run_test::<T, HOST>();
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,8 +89,8 @@ where
 {
     run_test::<T, WIRE>();
     run_test::<T, { make_usage(Compress::Yes, Validate::No) }>();
-    // run_test::<T,{ make_usage(Compress::No, Validate::Yes) }>();
-    run_test::<T, HOST>();
+    run_test::<T,{ make_usage(Compress::No, Validate::Yes) }>();
+    run_test::<T, HOST_CALL>();
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,7 @@ use ark_std::{cmp::PartialEq, fmt::Debug, vec::Vec, UniformRand}; // io::{self, 
 
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
-use parity_scale_codec::{Decode, Encode};
+use scale_codec::{Decode, Encode};
 
 use crate::{self as ark_scale, *};
 


### PR DESCRIPTION
- `TypeInfo` has been implemented roughly following https://github.com/w3f/ark-scale/issues/4

- `ArkScaleMaxEncodedLen::max_encoded_size()` now takes the `Compress` param.

`scale::MaxEncodedLen` is required to be implemented also for types the user may wish to serialize in the chain state as well (i.e. local pallet storage). For this data the user `ArkScale` type requires to implement `ArkScaleMaxEncodedLen` and the user may wish to serialize this data in compressed format but not validated.

I'm also using this to benchmark all the features provided by @achimcc  with different setups.

If this PR is accepted I've also ready a followup which applies this modification is a couple of places of `ring-vrf`.