### PR TITLE
Fix type info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl<T: 'static + ArkScaleMaxEncodedLen, const U: Usage> TypeInfo for ArkScale<T
     type Identity = Self;
 
     fn type_info() -> scale_info::Type {
-        let path = scale_info::Path::new(core::any::type_name::<Self>(), module_path!());
+        let path = scale_info::Path::new("ArkScale", module_path!());
         let array_type_def = scale_info::TypeDefArray {
             len: T::max_encoded_len(is_compressed(U)) as u32,
             type_param: scale_info::MetaType::new::<u8>(),


### PR DESCRIPTION
`TypeInfo` doesn't allow to have a `Path` with an `ident` parameter with invalid Rust identifier.

https://github.com/paritytech/scale-info/blob/68c85eeac67e512fc899c06f1d3eb274259caca1/src/ty/path.rs#L84-L91

Since `<` and `>` are not valid characters for identifiers we can't use the generic name for `Path` construction.

This is a good enough compromise
